### PR TITLE
Make defaultShowFallback method overridable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,8 @@ lazy val library = Project(libName, file("."))
         "org.scalatest"       %% "scalatest"    % "3.2.8"             % Test,
         "com.vladsch.flexmark" % "flexmark-all" % "0.36.8"            % Test,
         "org.scalacheck"      %% "scalacheck"   % "1.14.3"            % Test,
-        "com.typesafe.play"   %% "play-test"    % PlayVersion.current % Test
+        "com.typesafe.play"   %% "play-test"    % PlayVersion.current % Test,
+        "org.scalameta"       %% "munit"        % "0.7.29"            % Test
       ),
       play26 = Seq(
         "com.typesafe.play"      %% "play-json"          % "2.6.14",

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JourneyController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JourneyController.scala
@@ -187,6 +187,9 @@ trait JourneyController[RequestContext] {
       .map(getCallFor)
       .getOrElse(fallback.getOrElse(getCallFor(journeyService.model.root)))
 
+  /** Override to change the default behaviour of the [[actions.show[State]]]. */
+  lazy val defaultFallbackFromShow: Fallback = helpers.redirectToStartFallback
+
   /** FSM controller helper methods. */
   final object helpers {
 
@@ -371,9 +374,6 @@ trait JourneyController[RequestContext] {
         }
 
     final val redirectToCurrentStateFallback: Fallback = redirectToCurrentState(_, _, _)
-
-    /** Override to change the default behaviour of the [[actions.show[State]]]. */
-    val defaultShowFallback: Fallback = redirectToStartFallback
 
     //-------------------------------------------------
     // STATE RENDERING HELPERS
@@ -1314,8 +1314,11 @@ trait JourneyController[RequestContext] {
       }
 
       /**
-        * Display if the current state is of type S,
+        * Display current state if has type S,
         * otherwise redirect back to the root state.
+        *
+        * The default fallback behaviour can be altered per controller by
+        * overriding the [[defaultFallbackFromShow]] method.
         *
         * @tparam S type of the expected current state
         *
@@ -1334,7 +1337,7 @@ trait JourneyController[RequestContext] {
         new Show[S](
           rollback = false,
           merger = None,
-          fallback = JourneyController.this.helpers.defaultShowFallback
+          fallback = JourneyController.this.defaultFallbackFromShow
         ) with WithRollback[S] with WithApply[S] with WithRedirect[S]
 
       /** [[Show]] DSL data model. */

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JsonStateFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JsonStateFormats.scala
@@ -47,23 +47,13 @@ trait JsonStateFormats[State] {
   final val writes: Writes[State] = new Writes[State] {
     override def writes(state: State): JsValue =
       if (serializeStateProperties.isDefinedAt(state)) serializeStateProperties(state) match {
-        case JsNull     => Json.obj("state" -> nameOf(state))
-        case properties => Json.obj("state" -> nameOf(state), "properties" -> properties)
+        case JsNull => Json.obj("state" -> PlayFsmUtils.identityOf(state))
+        case properties =>
+          Json.obj("state" -> PlayFsmUtils.identityOf(state), "properties" -> properties)
       }
-      else Json.obj("state" -> nameOf(state))
+      else Json.obj("state" -> PlayFsmUtils.identityOf(state))
   }
 
   final def formats: Format[State] = Format(reads, writes)
-
-  final def nameOf(state: State): String = {
-    val className = state.getClass.getName
-    val lastDot   = className.lastIndexOf('.')
-    val typeName = {
-      val s = if (lastDot < 0) className else className.substring(lastDot + 1)
-      if (s.last == '$') s.init else s
-    }
-    val lastDollar = typeName.lastIndexOf('$')
-    if (lastDollar < 0) typeName else typeName.substring(lastDollar + 1)
-  }
 
 }

--- a/src/main/scala/uk/gov/hmrc/play/fsm/PlayFsmUtils.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/PlayFsmUtils.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.fsm
+
+import scala.annotation.tailrec
+
+object PlayFsmUtils {
+
+  final def identityOf[A](entity: A): String = {
+
+    @tailrec
+    def simpleNameOf(clazz: Class[_], suffix: String): String = {
+      val name = clazz.getName()
+      val id   = normalize(name)
+      if (name.contains("$anon$"))
+        simpleNameOf(entity.getClass().getSuperclass(), combine(id, suffix))
+      else
+        combine(id, suffix)
+    }
+
+    simpleNameOf(entity.getClass(), "")
+  }
+
+  final def normalize(name: String): String = {
+    val name1 =
+      if (name.endsWith("$") || name.endsWith(".")) name.dropRight(1)
+      else name
+    val name2 = {
+      val i = Math.max(name1.lastIndexOf("."), name1.lastIndexOf("$")) + 1
+      name1.substring(i)
+    }
+    name2
+  }
+
+  @inline final def combine(a: String, b: String): String =
+    if (a.isEmpty())
+      b
+    else if (b.isEmpty())
+      a
+    else
+      s"$a:$b"
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/fsm/Diff.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/Diff.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.fsm
+
+object Diff {
+
+  def apply[A](left: A, right: A): String =
+    new munit.internal.difflib.Diff(prettyPrint(left), prettyPrint(right)).createDiffOnlyReport()
+
+  /**
+    * Pretty prints a Scala value similar to its source represention.
+    *
+    * Credits: https://gist.github.com/carymrobbins/7b8ed52cd6ea186dbdf8
+    *
+    * @param a - The value to pretty print.
+    * @param indentSize - Number of spaces for each indent.
+    * @param maxElementWidth - Largest element size before wrapping.
+    * @param depth - Initial depth to pretty print indents.
+    * @return
+    */
+  private def prettyPrint(
+    a: Any,
+    indentSize: Int = 2,
+    maxElementWidth: Int = 30,
+    depth: Int = 0
+  ): String = {
+    val indent      = " " * depth * indentSize
+    val fieldIndent = indent + (" " * indentSize)
+    val thisDepth   = prettyPrint(_: Any, indentSize, maxElementWidth, depth)
+    val nextDepth   = prettyPrint(_: Any, indentSize, maxElementWidth, depth + 1)
+    a match {
+      // Make Strings look similar to their literal form.
+      case s: String =>
+        val replaceMap = Seq(
+          "\n" -> "\\n",
+          "\r" -> "\\r",
+          "\t" -> "\\t",
+          "\"" -> "\\\""
+        )
+        '"' + replaceMap.foldLeft(s) { case (acc, (c, r)) => acc.replace(c, r) } + '"'
+      // For an empty Seq just use its normal String representation.
+      case xs: Seq[_] if xs.isEmpty => xs.toString()
+      case xs: Seq[_]               =>
+        // If the Seq is not too long, pretty print on one line.
+        val resultOneLine = xs.map(nextDepth).toString()
+        if (resultOneLine.length <= maxElementWidth) return resultOneLine
+        // Otherwise, build it with newlines and proper field indents.
+        val result = xs.map(x => s"\n$fieldIndent${nextDepth(x)}").toString()
+        result.substring(0, result.length - 1) + "\n" + indent + ")"
+      // Product should cover case classes.
+      case p: Product =>
+        val prefix = p.productPrefix
+        // We'll use reflection to get the constructor arg names and values.
+        val cls    = p.getClass
+        val fields = cls.getDeclaredFields.filterNot(_.isSynthetic).map(_.getName)
+        val values = p.productIterator.toSeq
+        // If we weren't able to match up fields/values, fall back to toString.
+        if (fields.length != values.length) return p.toString
+        fields.zip(values).toList match {
+          // If there are no fields, just use the normal String representation.
+          case Nil => p.toString
+          // If there is just one field, let's just print it as a wrapper.
+          case (_, value) :: Nil => s"$prefix(${thisDepth(value)})"
+          // If there is more than one field, build up the field names and values.
+          case kvps =>
+            val prettyFields = kvps.map { case (k, v) => s"$fieldIndent$k = ${nextDepth(v)}" }
+            // If the result is not too long, pretty print on one line.
+            val resultOneLine = s"$prefix(${prettyFields.mkString(", ")})"
+            if (resultOneLine.length <= maxElementWidth) return resultOneLine
+            // Otherwise, build it with newlines and proper field indents.
+            s"$prefix(\n${prettyFields.mkString(",\n")}\n$indent)"
+        }
+      // If we haven't specialized this type, just use its toString.
+      case _ => a.toString
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerSpec.scala
@@ -211,6 +211,13 @@ class DummyJourneyControllerSpec
       journeyState.get should have[State](State.Start, Nil)
     }
 
+    "given Continue when showStart then redirect to root state" in {
+      journeyState.set(State.Continue("foo"), Nil)
+      val result = controller.showStart(fakeRequest)
+      status(result) shouldBe 303
+      journeyState.get should have[State](State.Start, Nil)
+    }
+
     "given Continue when oldShowStart then display most recent Start" in {
       journeyState.set(State.Continue("dummy"), List(State.Start))
       val result = controller.oldShowStart(fakeRequest)

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShow.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShow.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.fsm
+import akka.actor.ActorSystem
+import play.api.mvc._
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+@Singleton
+class DummyJourneyControllerWithOverridenFallbackFromShow @Inject() (
+  a: DummyJourneyService,
+  b: DefaultActionBuilder,
+  c: ControllerComponents
+)(implicit
+  ec: ExecutionContext,
+  actorSystem: ActorSystem
+) extends DummyJourneyController(a, b, c) {
+
+  override lazy val defaultFallbackFromShow: Fallback =
+    (requestContext: DummyContext, request: Request[_], executionContext: ExecutionContext) =>
+      Future.successful(NotFound)
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShowSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShowSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.fsm
+
+import akka.actor.Scheduler
+import akka.stream.Materializer
+import org.scalatestplus.play.OneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.FiniteDuration
+import scala.language.postfixOps
+
+class DummyJourneyControllerWithOverridenFallbackFromShowSpec
+    extends UnitSpec
+    with OneAppPerSuite
+    with StateAndBreadcrumbsMatchers {
+
+  import scala.concurrent.duration._
+
+  implicit override val defaultTimeout: FiniteDuration = 360 seconds
+
+  implicit val scheduler: Scheduler = app.actorSystem.scheduler
+
+  implicit lazy val materializer: Materializer = app.materializer
+
+  override lazy val app: Application =
+    new GuiceApplicationBuilder().build()
+
+  lazy val journeyState: DummyJourneyService =
+    app.injector.instanceOf[DummyJourneyService]
+
+  lazy val controller: DummyJourneyControllerWithOverridenFallbackFromShow =
+    app.injector.instanceOf[DummyJourneyControllerWithOverridenFallbackFromShow]
+
+  import journeyState.model.State
+
+  def fakeRequest = FakeRequest()
+
+  "DummyJourneyControllerWithOverridenFallbackFromShow" should {
+
+    "in state Start render a page after showStart" in {
+      journeyState.set(State.Start, Nil)
+      val result = controller.showStart(fakeRequest)
+      status(result) shouldBe 200
+      journeyState.get should have[State](State.Start, Nil)
+    }
+
+    "in state Continue render an error after showStart" in {
+      journeyState.set(State.Continue("foo"), List(State.Start))
+      val result = controller.showStart(fakeRequest)
+      status(result) shouldBe 404
+      journeyState.get should have[State](State.Continue("foo"), List(State.Start))
+    }
+
+    "in state Continue go to Stop after stopDsl12" in {
+      journeyState.set(State.Continue("foo"), List(State.Start))
+      val result = controller.stopDsl12(fakeRequest)
+      status(result) shouldBe 303
+      journeyState.get should have[State](
+        State.Stop("foo"),
+        List(State.Continue("foo"), State.Start)
+      )
+    }
+  }
+
+}

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModelSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModelSpec.scala
@@ -16,7 +16,15 @@
 
 package uk.gov.hmrc.play.fsm
 
-class DummyJourneyModelSpec extends UnitSpec with JourneyModelSpec {
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+class DummyJourneyModelSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with JourneyModelSpec {
 
   override val model = DummyJourneyModel
 

--- a/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.play.fsm
 import org.scalatest.matchers.MatchResult
 import org.scalatest.matchers.Matcher
 import org.scalatest.matchers.should.Matchers
-import uk.gov.hmrc.play.fsm.JourneyModel
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -148,20 +147,22 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
             if (state != result.initialState && thisState == result.initialState)
               MatchResult(
                 false,
-                s"New state ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} has been expected but the transition didn't happen.",
+                s"New state ${AnsiColor.CYAN}${PlayFsmUtils.identityOf(state)}${AnsiColor.RESET} has been expected but the transition didn't happen.",
                 s""
               )
             else if (state.getClass() == thisState.getClass()) {
               val diff = Diff(thisState, state)
               MatchResult(
                 false,
-                s"Obtained state ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} content differs from the expected:\n$diff}",
+                s"Obtained state ${AnsiColor.CYAN}${PlayFsmUtils
+                  .identityOf(state)}${AnsiColor.RESET} content differs from the expected:\n$diff}",
                 s""
               )
             } else
               MatchResult(
                 false,
-                s"State ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} has been expected but got state ${AnsiColor.CYAN}${nameOf(thisState)}${AnsiColor.RESET}",
+                s"State ${AnsiColor.CYAN}${PlayFsmUtils.identityOf(state)}${AnsiColor.RESET} has been expected but got state ${AnsiColor.CYAN}${PlayFsmUtils
+                  .identityOf(thisState)}${AnsiColor.RESET}",
                 s""
               )
 
@@ -242,17 +243,6 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
   // Delete the temp file
   override def afterAll() {
     info(s"Test suite executed ${getCounter()} state transitions in total.")
-  }
-
-  private def nameOf(state: model.State): String = {
-    val className = state.getClass.getName
-    val lastDot   = className.lastIndexOf('.')
-    val typeName = {
-      val s = if (lastDot < 0) className else className.substring(lastDot + 1)
-      if (s.last == '$') s.init else s
-    }
-    val lastDollar = typeName.lastIndexOf('$')
-    if (lastDollar < 0) typeName else typeName.substring(lastDollar + 1)
   }
 
 }

--- a/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.play.fsm
 import org.scalatest.matchers.MatchResult
 import org.scalatest.matchers.Matcher
 import org.scalatest.matchers.should.Matchers
+import uk.gov.hmrc.play.fsm.JourneyModel
 
 import scala.concurrent.Await
 import scala.concurrent.Future
@@ -26,6 +27,9 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import org.scalactic.source
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Informing
+import scala.io.AnsiColor
 
 /**
   * Abstract base of FSM journey specifications.
@@ -51,22 +55,21 @@ import org.scalactic.source
   *     .thenFailsWith[SomeExceptionType]
   */
 trait JourneyModelSpec extends TestJourneyService[DummyContext] {
-  self: Matchers =>
+  self: Matchers with BeforeAndAfterAll with Informing =>
 
   val model: JourneyModel
+
+  implicit val defaultTimeout: FiniteDuration = 5 seconds
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A =
+    Await.result(future, timeout)
 
   /** Assumption about the initial state of journey. */
   case class given[S <: model.State: ClassTag](
     initialState: S,
     breadcrumbs: List[model.State] = Nil
   ) {
-
-    import scala.concurrent.ExecutionContext.Implicits.global
-
-    private def await[A](future: Future[A])(implicit timeout: Duration): A =
-      Await.result(future, timeout)
-
-    implicit val defaultTimeout: FiniteDuration = 5 seconds
 
     final def withBreadcrumbs(breadcrumbs: model.State*): given[S] =
       given(initialState, breadcrumbs.toList)
@@ -145,11 +148,22 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
             if (state != result.initialState && thisState == result.initialState)
               MatchResult(
                 false,
-                s"New state $state has been expected but the transition didn't happen.",
+                s"New state ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} has been expected but the transition didn't happen.",
                 s""
               )
-            else
-              MatchResult(false, s"State $state has been expected but got state $thisState", s"")
+            else if (state.getClass() == thisState.getClass()) {
+              val diff = Diff(thisState, state)
+              MatchResult(
+                false,
+                s"Obtained state ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} content differs from the expected:\n$diff}",
+                s""
+              )
+            } else
+              MatchResult(
+                false,
+                s"State ${AnsiColor.CYAN}${nameOf(state)}${AnsiColor.RESET} has been expected but got state ${AnsiColor.CYAN}${nameOf(thisState)}${AnsiColor.RESET}",
+                s""
+              )
 
           case _ =>
             MatchResult(true, "", s"")
@@ -164,7 +178,11 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
       override def apply(result: When): MatchResult =
         result match {
           case When(_, Left(exception)) =>
-            MatchResult(false, s"Transition has been expected but got an exception $exception", s"")
+            MatchResult(
+              false,
+              s"Transition has been expected but got an exception: ${AnsiColor.RED}$exception${AnsiColor.RESET}",
+              s""
+            )
 
           case When(_, Right((thisState, _))) if !statePF.isDefinedAt(thisState) =>
             MatchResult(false, s"Matching state has been expected but got state $thisState", s"")
@@ -179,7 +197,11 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
       override def apply(result: When): MatchResult =
         result match {
           case When(_, Left(exception)) =>
-            MatchResult(false, s"Transition has been expected but got an exception $exception", s"")
+            MatchResult(
+              false,
+              s"Transition has been expected but got an exception: ${AnsiColor.RED}$exception${AnsiColor.RESET}",
+              s""
+            )
 
           case When(initialState, Right((thisState, _))) if thisState != initialState =>
             MatchResult(false, s"No state change has been expected but got state $thisState", s"")
@@ -198,15 +220,17 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
           case When(_, Left(exception)) if !expectedClass.isAssignableFrom(exception.getClass) =>
             MatchResult(
               false,
-              s"Exception of type ${expectedClass
-                .getName()} has been expected but got exception of type ${exception.getClass().getName()}",
+              s"Exception of type ${AnsiColor.RED}${expectedClass
+                .getName()}${AnsiColor.RESET} has been expected but got exception of type ${AnsiColor.RED}${exception
+                .getClass()
+                .getName()}${AnsiColor.RESET}",
               s""
             )
 
           case When(initialState, Right((thisState, _))) =>
             MatchResult(
               false,
-              s"Exception of type ${expectedClass.getName()} has been expected but got state $thisState",
+              s"Exception of type ${AnsiColor.RED}${expectedClass.getName()}${AnsiColor.RESET} has been expected but got state $thisState",
               s""
             )
 
@@ -214,5 +238,21 @@ trait JourneyModelSpec extends TestJourneyService[DummyContext] {
             MatchResult(true, "", s"")
         }
     }
+
+  // Delete the temp file
+  override def afterAll() {
+    info(s"Test suite executed ${getCounter()} state transitions in total.")
+  }
+
+  private def nameOf(state: model.State): String = {
+    val className = state.getClass.getName
+    val lastDot   = className.lastIndexOf('.')
+    val typeName = {
+      val s = if (lastDot < 0) className else className.substring(lastDot + 1)
+      if (s.last == '$') s.init else s
+    }
+    val lastDollar = typeName.lastIndexOf('$')
+    if (lastDollar < 0) typeName else typeName.substring(lastDollar + 1)
+  }
 
 }

--- a/src/test/scala/uk/gov/hmrc/play/fsm/PlayFsmUtilsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/PlayFsmUtilsSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.play.fsm
+
+class PlayFsmUtilsSpec extends UnitSpec {
+
+  class A
+  case class B1()
+  trait Cx
+  object Dd {
+    class E {
+      trait Gaga extends Cx
+      trait Ii extends A
+    }
+    trait Foo
+    case class Ha() extends Foo with Cx
+    case object Jay
+    case object Key {
+      case class EL()
+    }
+  }
+
+  "PlayFsmUtils" should {
+    "normalize a name" in {
+      PlayFsmUtils.normalize("")          shouldBe ""
+      PlayFsmUtils.normalize(".")         shouldBe ""
+      PlayFsmUtils.normalize("..")        shouldBe ""
+      PlayFsmUtils.normalize("A.")        shouldBe "A"
+      PlayFsmUtils.normalize("a.ABC.")    shouldBe "ABC"
+      PlayFsmUtils.normalize("a.b.$Bcd$") shouldBe "Bcd"
+      PlayFsmUtils.normalize("a.b.$Bcd")  shouldBe "Bcd"
+      PlayFsmUtils.normalize("a.b.Bcd")   shouldBe "Bcd"
+    }
+
+    "return an identity of a state type" in {
+      PlayFsmUtils.identityOf(new A)         shouldBe "A"
+      PlayFsmUtils.identityOf(B1())          shouldBe "B1"
+      PlayFsmUtils.identityOf(new Cx {})     shouldBe "Object:1"
+      PlayFsmUtils.identityOf(Dd)            shouldBe "Dd"
+      PlayFsmUtils.identityOf(new A {})      shouldBe "A:2"
+      PlayFsmUtils.identityOf(new Dd.E)      shouldBe "E"
+      PlayFsmUtils.identityOf(new Dd.Foo {}) shouldBe "Object:3"
+      PlayFsmUtils.identityOf(Dd.Ha())       shouldBe "Ha"
+      PlayFsmUtils.identityOf { val e = new Dd.E; new e.Gaga {} } shouldBe "Object:4"
+      PlayFsmUtils.identityOf { val e = new Dd.E; new e.Ii {} } shouldBe "A:5"
+      PlayFsmUtils.identityOf(Dd.Jay)      shouldBe "Jay"
+      PlayFsmUtils.identityOf(Dd.Key)      shouldBe "Key"
+      PlayFsmUtils.identityOf(Dd.Key.EL()) shouldBe "EL"
+    }
+
+  }
+}


### PR DESCRIPTION
This PR fixes an issue with the method `defaultShowFallback`, which should be declared directly in the `JourneyController` but wrongly was put inside `helpers` object. The method has been moved back and renamed to `defaultFallbackFromShow`.

Currently, the default behaviour of the `show[X]` action when the state is not X is to redirect the user back to the start state. This change enables controller-wide customization by overriding `defaultFallbackFromShow` with custom functionality.