### PR TITLE
fix switching-language, add feature to filter out unrelated flash keys

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += Resolver.url(
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
@@ -14,7 +14,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "2.3.0")
 
 val playPlugin =
   if (sys.env.get("PLAY_VERSION").contains("2.6"))

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JourneyController.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JourneyController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JourneyIdSupport.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JourneyIdSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JourneyModel.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JourneyModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JourneyService.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JourneyService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/JsonStateFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/JsonStateFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/PlayFsmUtils.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/PlayFsmUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/play/fsm/ScheduleAfter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/fsm/ScheduleAfter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/Diff.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/Diff.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyContext.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyController.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShow.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShowSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyControllerWithOverridenFallbackFromShowSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModel.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModelSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyService.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyStateFormats.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyStateFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyStateFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyStateFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyWithIdController.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyWithIdController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyWithIdControllerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/DummyJourneyWithIdControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/InMemoryStore.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/InMemoryStore.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/JourneyModelSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/OptionalFormOpsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/OptionalFormOpsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,24 @@ class OptionalFormOpsSpec extends UnitSpec {
     "return the second arg if first arg is None and request flash cookie is Empty" in {
       implicit val request: Request[AnyContent] = FakeRequest()
       None.or(form) shouldBe form
+    }
+
+    "ignore known unrelated flash keys" in {
+      implicit val request: Request[AnyContent] =
+        FakeRequest().withFlash("dummy" -> "", "switching-language" -> "true")
+      None.or(form).errors shouldBe form.bind(Map.empty[String, String]).errors
+    }
+
+    "bind ignoring known unrelated flash keys" in {
+      implicit val request: Request[AnyContent] =
+        FakeRequest().withFlash("switching-language" -> "true", "arg" -> "123")
+      None.or(form).value shouldBe form.bind(Map("arg" -> "123")).value
+    }
+
+    "fill default ignoring known unrelated flash keys" in {
+      implicit val request: Request[AnyContent] =
+        FakeRequest().withFlash("switching-language" -> "true")
+      None.or(form, Some(456)).value shouldBe form.bind(Map("arg" -> "456")).value
     }
   }
 }

--- a/src/test/scala/uk/gov/hmrc/play/fsm/PlayFsmUtilsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/PlayFsmUtilsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/StateAndBreadcrumbsMatchers.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/StateAndBreadcrumbsMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyModel.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyService.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyServiceSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/TestJourneyServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/TestPayload.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/TestPayload.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/play/fsm/UnitSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/fsm/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR fixes an issue where flash data contains unrelated keys interfering with OptionalFormOps.of and forcing form binding errors instead of returning an empty form or populating form with the default value.